### PR TITLE
fix(Alphabet): prevent hoisting error in jest environment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,12 +7,14 @@ import {
 } from './baseN.js';
 
 // base58 characters (Bitcoin alphabet)
-const alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+function getAlphabet () {
+  return '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+}
 
 export function encode(input, maxline) {
-  return _encode(input, alphabet, maxline);
+  return _encode(input, getAlphabet(), maxline);
 }
 
 export function decode(input) {
-  return _decode(input, alphabet);
+  return _decode(input, getAlphabet());
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "BSD-3-Clause",
   "type": "module",
   "exports": "./lib/index.js",
+  "main": "./lib/index.js",
   "files": [
     "lib/**/*.js"
   ],


### PR DESCRIPTION
I am not sure how jest does things differently, but I keep hitting this error and so I think it would be beneficial for all consumers to run a valid version.

When running this code in jest, I get the following error:
```
ReferenceError: Cannot access 'alphabet' before initialization
```

I don't think I have seen it in node nor the browser, but since it does not break the tests, I think it's a small change that would increase stability (and remove false negatives in my case).

Thanks